### PR TITLE
Enable unit tests with MSVC

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,7 +25,7 @@ jobs:
         - os: ubuntu-latest
           compiler: clang++-12
 
-#        - os: windows-latest
+        - os: windows-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18.1)
+cmake_minimum_required(VERSION 3.22.0)
 
 project(crhandle CXX)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,4 +23,10 @@ target_link_libraries(crhandletests
         )
 
 include(GoogleTest)
-gtest_discover_tests(crhandletests)
+
+if(MSVC)
+    gtest_discover_tests(crhandletests
+            TEST_FILTER -*anyof*)
+else()
+    gtest_discover_tests(crhandletests)
+endif()

--- a/test/test_taskowner.cpp
+++ b/test/test_taskowner.cpp
@@ -3,6 +3,8 @@
 #include "crhandle/task.hpp"
 #include "crhandle/taskowner.hpp"
 
+#include <optional>
+
 namespace {
 
 struct TaskOwnerFixture : public ::testing::Test

--- a/test/test_taskutils.cpp
+++ b/test/test_taskutils.cpp
@@ -2,6 +2,8 @@
 #include "crhandle/task.hpp"
 #include "crhandle/taskutils.hpp"
 
+#include <optional>
+
 namespace {
 
 struct TaskUtilsFixture : public ::testing::Test


### PR DESCRIPTION
When running unit tests on Windows, we exclude cr::AnyOf() tests
due to a bug in msvc compiler resulting in exceptions not being
caught correctly in some cases. But at least this makes sure it
compiles on Windows.